### PR TITLE
add property 'blurSuperView'

### DIFF
--- a/LiveFrost/LFGlassView.h
+++ b/LiveFrost/LFGlassView.h
@@ -5,5 +5,6 @@
 
 @property (nonatomic, assign) CGFloat blurRadius;
 @property (nonatomic, assign) CGFloat scaleFactor;
+@property (nonatomic, strong) UIView *blurSuperView;
 
 @end

--- a/LiveFrost/LFGlassView.m
+++ b/LiveFrost/LFGlassView.m
@@ -179,19 +179,23 @@
 }
 
 - (void) refresh {
-	if (!self.superview) {
+	if (!self.blurSuperView) {
+        self.blurSuperView = self.superview;
+    }
+    
+	if (!self.blurSuperView) {
 		return;
 	}
 	
 	[self recreateImageBuffersIfNeeded];
-		
+    
 	CGContextRef effectInContext = _effectInContext;
 	CGContextRef effectOutContext = _effectOutContext;
 	vImage_Buffer effectInBuffer = _effectInBuffer;
 	vImage_Buffer effectOutBuffer = _effectOutBuffer;
 	
 	self.hidden = YES;
-	[self.superview.layer renderInContext:effectInContext];
+	[self.blurSuperView.layer renderInContext:effectInContext];
 	self.hidden = NO;
 	
 	uint32_t blurKernel = _precalculatedBlurKernel;


### PR DESCRIPTION
Hi, I use this in my component which is a custom alert view.
And my problem is,  when I show the alert view, actually it was created on another window.
Therefore I add a new property `blurSuperView`. When `refresh` been call, it check if blurSuperView had been set to other view. if not, use superview as backgroundView.

Hope this is useful for others.
