### PR TITLE
Use correct URLs in podspec

### DIFF
--- a/LiveFrost.podspec
+++ b/LiveFrost.podspec
@@ -2,13 +2,13 @@ Pod::Spec.new do |s|
   s.name         = "LiveFrost"
   s.version      = "1.0.2"
   s.summary      = "Real time blurring."
-  s.homepage     = "http://github.com/radi/LiveFrost"
+  s.homepage     = "https://github.com/radi/LiveFrost"
   s.license      = 'MIT'
   s.author       = {
     "Evadne Wu" => "ev@radi.ws",
     "Nicholas Gabriel Levin" => "nglevin@vivarium.gs"
   }
-  s.source       = { :git => "git@github.com:radi/LiveFrost.git", :tag => "1.0.2" }
+  s.source       = { :git => "https://github.com/radi/LiveFrost.git", :tag => "1.0.2" }
   s.platform     = :ios, '6.0'
   s.source_files = 'LiveFrost', 'LiveFrost/**/*.{h,m}'
   s.exclude_files = 'LiveFrost/Exclude'


### PR DESCRIPTION
Not sure if you want this in `develop` along with the other stuff.  Cocoapods needs the HTTPS URL.
