### PR TITLE
Allow to assign a view to blur.

### DIFF
--- a/LiveFrost/LFGlassView.h
+++ b/LiveFrost/LFGlassView.h
@@ -33,6 +33,7 @@
 @property (nonatomic, assign) NSUInteger frameInterval;
 
 @property (nonatomic, assign, getter=isLiveBlurring) BOOL liveBlurring;
+@property (nonatomic, strong) UIView *blurringView;
 
 - (BOOL) blurOnceIfPossible;
 

--- a/LiveFrost/LFGlassView.m
+++ b/LiveFrost/LFGlassView.m
@@ -320,9 +320,9 @@
 	}
 	_currentFrameInterval = 0;
 	
-	UIView *superview = self.superview;
+	UIView *blurringView = self.blurringView ? : self.superview;
 #ifdef DEBUG
-	NSParameterAssert(superview);
+	NSParameterAssert(blurringView);
 	NSParameterAssert(self.window);
 	NSParameterAssert(_effectInContext);
 	NSParameterAssert(_effectOutContext);
@@ -334,7 +334,7 @@
 	vImage_Buffer effectOutBuffer = _effectOutBuffer;
 	
 	self.hidden = YES;
-	[superview.layer renderInContext:effectInContext];
+	[blurringView.layer renderInContext:effectInContext];
 	self.hidden = NO;
 	
 	uint32_t blurKernel = _precalculatedBlurKernel;


### PR DESCRIPTION
Some times the blurring view is added in another window or in a containerView resulting in unintended effects

This fixes that by allowing to set one.
